### PR TITLE
don't rescue ALL exceptions and throw exception when chrome client do…

### DIFF
--- a/lib/postdoc/chrome_process.rb
+++ b/lib/postdoc/chrome_process.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Postdoc
   class ChromeProcess
     attr_reader :pid, :port
@@ -11,7 +12,7 @@ module Postdoc
 
     def alive?
       @alive ||= test_socket!
-    rescue
+    rescue Errno::ECONNREFUSED
       false
     end
 

--- a/lib/postdoc/client.rb
+++ b/lib/postdoc/client.rb
@@ -9,6 +9,7 @@ module Postdoc
     def initialize(port)
       @port = port
       100.times { setup_connection_or_wait && break }
+      raise 'ChromeClient couldn\'t launch' if @client.blank?
     end
 
     def print_pdf_from_html(file_path,
@@ -38,7 +39,7 @@ module Postdoc
     def setup_connection_or_wait
       @client = ChromeRemote.client(port: @port)
       true
-    rescue
+    rescue Errno::ECONNREFUSED
       sleep(0.1)
       false
     end


### PR DESCRIPTION
Better error messages.