### PR TITLE
Support Rails 6.1

### DIFF
--- a/postdoc.gemspec
+++ b/postdoc.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'LICENSE', 'Rakefile']
 
   s.add_dependency 'chrome_remote', '>= 0.2.0'
-  s.add_dependency 'rails', '>= 4.0.0', '< 6.1'
+  s.add_dependency 'rails', '>= 4.0.0', '< 7.0'
   s.add_development_dependency 'mocha'
 end


### PR DESCRIPTION
Hi @basschoen, @jaspervandenberg,
It seems the rails dependency restriction does not work with current stable rails. This patch fixes it. Could you publish a new gem to rubygems.org as well? Thanks!