### PR TITLE
Allow all remote origins

### DIFF
--- a/lib/postdoc/chrome_process.rb
+++ b/lib/postdoc/chrome_process.rb
@@ -7,7 +7,7 @@ module Postdoc
 
     def initialize(port: Random.rand(1025..65535), **_options)
       @port = port
-      @pid = Process.spawn "chrome --remote-debugging-port=#{port} --headless",
+      @pid = Process.spawn "chrome --remote-debugging-port=#{port} --headless --remote-allow-origins=*",
           out: File::NULL, err: File::NULL
     end
 


### PR DESCRIPTION
Starting from Chrome 111 this argument is required to connect to it.