### PR TITLE
Always open an empty Chrome tab

### DIFF
--- a/lib/postdoc/chrome_process.rb
+++ b/lib/postdoc/chrome_process.rb
@@ -7,7 +7,7 @@ module Postdoc
 
     def initialize(port: Random.rand(1025..65535), **_options)
       @port = port
-      @pid = Process.spawn "chrome --remote-debugging-port=#{port} --headless",
+      @pid = Process.spawn "chrome --remote-debugging-port=#{port} --headless about:blank",
           out: File::NULL, err: File::NULL
     end
 


### PR DESCRIPTION
Without this there are not inspectable targets causing ChromeRemote to fail connecting.

This started failing a few Chrome versions ago. Solved thanks to https://stackoverflow.com/questions/75837204/google-chrome-headless-remote-debugging-no-response-on-json-url#comment133898328_75864268